### PR TITLE
add useShouldNestedElementRender for NestableNavigationContent

### DIFF
--- a/ui-kit-lib/src/main/kotlin/com/linkedplanet/uikit/wrapper/atlaskit/sidenavigation/Imports.kt
+++ b/ui-kit-lib/src/main/kotlin/com/linkedplanet/uikit/wrapper/atlaskit/sidenavigation/Imports.kt
@@ -139,11 +139,28 @@ external interface NestingItemProps : Props {
 }
 
 /**
- * A custom item can be used to a
- *  - Provide a link to an external page
- *  - Contain a custom functional component with arbitrary content
- *  Not wrapping custom components in CustomItem leads to reappearing components in nested menus.
+ *   Sometimes you'll want to use components that aren't supplied by this library,
+ *   and that's great!
+ *   However, you'll need to know that when you do if you don't opt into our "should I render" hook -
+ *   your element will be rendered on _every_ nested view,
+ *   which may or may not be what you want to happen.
  *
+ *   When writing a leaf node component, you'll want to conditionally return `null` (if shouldRender is false)
+ *   When writing a wrapping component, you'll want to conditionally return `children` (if shouldRender is false)
+ *
+ */
+@JsName("useShouldNestedElementRender")
+external val useShouldNestedElementRender: () -> ShouldRender
+
+external interface ShouldRender {
+    val shouldRender: Boolean
+}
+
+/**
+ * Useful when wanting to create a item using a your own component that inherits the look and feel of a menu item.
+ * Use cases could include using your own router link component for example.
+ *
+ * The original component passes on props. The wrapper does not support this at this time.
  */
 @JsName("CustomItem")
 external val CustomItem: ComponentClass<CustomItemProps>

--- a/ui-kit-showcase/src/main/kotlin/com/linkedplanet/uikit/component/ShowcaseLeftSidebar.kt
+++ b/ui-kit-showcase/src/main/kotlin/com/linkedplanet/uikit/component/ShowcaseLeftSidebar.kt
@@ -15,22 +15,54 @@
  */
 package com.linkedplanet.uikit.component
 
+import com.linkedplanet.uikit.wrapper.atlaskit.button.Button
 import com.linkedplanet.uikit.wrapper.atlaskit.icon.EmojiTravelIcon
 import com.linkedplanet.uikit.wrapper.atlaskit.icon.FileIcon
 import com.linkedplanet.uikit.wrapper.atlaskit.pagelayout.LeftSidebar
 import com.linkedplanet.uikit.wrapper.atlaskit.sidenavigation.*
+import com.linkedplanet.uikit.wrapper.atlaskit.textfield.TextField
+import csstype.FlexDirection
 import kotlinx.browser.document
 import kotlinx.js.jso
+import org.w3c.dom.HTMLInputElement
 import overrideBackButton
-import react.Props
-import react.RBuilder
-import react.createElement
+import react.*
 import react.dom.a
-import react.fc
+import react.dom.html.ReactHTML.div
 
 external interface ShowcaseLeftSidebarProps : Props
 
-val ShowcaseLeftSidebar = fc<ShowcaseLeftSidebarProps> { _ ->
+val textFieldWithClearButtonCustomComponent = FC<Props> {
+    val nestedElement = useShouldNestedElementRender()
+    var data by useState("")
+
+    if (!nestedElement.shouldRender){
+        return@FC
+    }
+    div {
+        style = jso {
+            display = csstype.Display.flex
+            flexDirection = FlexDirection.row
+        }
+        TextField {
+            placeholder = "Custom TextField"
+            value = data
+            isCompact = true
+            type = "text"
+            onChange ={
+                data = (it.target as HTMLInputElement).value.trim()
+            }
+        }
+        Button {
+            onClick = {
+                data = ""
+            }
+            + "Clear"
+        }
+    }
+}
+
+val ShowcaseLeftSidebar = fc<ShowcaseLeftSidebarProps> {
 
     LeftSidebar {
 
@@ -83,6 +115,12 @@ val ShowcaseLeftSidebar = fc<ShowcaseLeftSidebarProps> { _ ->
                                         +"The end!"
                                     }
                                 }
+                            }
+                        }
+
+                        Section {
+                            attrs.title = "Custom Component Section"
+                            textFieldWithClearButtonCustomComponent {
                             }
                         }
 


### PR DESCRIPTION
Allows to create custom components that are only rendered at the correct nesting level.